### PR TITLE
Fix config indent when PRINT_RARE_PARAMS is enabled

### DIFF
--- a/gd77.c
+++ b/gd77.c
@@ -1013,6 +1013,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:

--- a/md380.c
+++ b/md380.c
@@ -886,6 +886,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:

--- a/rd5r.c
+++ b/rd5r.c
@@ -1014,6 +1014,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:

--- a/uv380.c
+++ b/uv380.c
@@ -913,7 +913,7 @@ static void print_digital_channels(FILE *out, int verbose)
     }
     fprintf(out, "Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact");
 #ifdef PRINT_EXTENDED_PARAMS
-    fprintf(out, "AS InCall Sq Dly RxRef TxRef LW VOX EmSys Privacy  PN PCC EAA DCC DCDM");
+    fprintf(out, " AS InCall Sq Dly RxRef TxRef LW VOX EmSys Privacy  PN PCC EAA DCC DCDM");
 #endif
     fprintf(out, "\n");
     for (i=0; i<NCHAN; i++) {
@@ -943,6 +943,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-5d", ch->contact_name_index);
 
 #ifdef PRINT_EXTENDED_PARAMS
+        fprintf(out, "     "):
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:


### PR DESCRIPTION
Without:
```
Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact Dly VOX TA EmSys Privacy  PN PCC EAA DCC
   19   OK0BRQ-CZ        439.550   -7.6     High  4    -   -  -      1     1    1    1   5   -   -  -     -        -  -   -   -    # National Czech
```

After this patch:
```
Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact Dly VOX TA EmSys Privacy  PN PCC EAA DCC
   19   OK0BRQ-CZ        439.550   -7.6     High  4    -   -  -      1     1    1    1         5   -   -  -     -        -  -   -   -    # National Czech
```