### PR TITLE
Fix config indent and header when PRINT_RARE_PARAMS is enabled

### DIFF
--- a/gd77.c
+++ b/gd77.c
@@ -944,10 +944,8 @@ static void print_chan_base(FILE *out, channel_t *ch, int cnum)
 //
 // Print extended parameters of the channel:
 //      TOT Rekey Delay
-//      RX Ref Frequency
-//      RX Ref Frequency
-//      Lone Worker
 //      VOX
+//      Talkaround
 //
 static void print_chan_ext(FILE *out, channel_t *ch)
 {
@@ -1013,6 +1011,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:
@@ -1075,7 +1075,7 @@ static void print_analog_channels(FILE *out, int verbose)
     }
     fprintf(out, "Analog  Name             Receive   Transmit Power Scan TOT RO Admit  Squelch RxTone TxTone Width");
 #ifdef PRINT_RARE_PARAMS
-    fprintf(out, " Dly RxRef TxRef LW VOX TA RxSign TxSign");
+    fprintf(out, " Dly VOX TA RxSign TxSign");
 #endif
     fprintf(out, "\n");
     for (i=0; i<NCHAN; i++) {
@@ -1099,7 +1099,7 @@ static void print_analog_channels(FILE *out, int verbose)
         print_tone(out, ch->ctcss_dcs_receive);
         fprintf(out, "  ");
         print_tone(out, ch->ctcss_dcs_transmit);
-        fprintf(out, "  %s", BANDWIDTH[ch->bandwidth]);
+        fprintf(out, "  %-6s", BANDWIDTH[ch->bandwidth]);
 
 #ifdef PRINT_RARE_PARAMS
         print_chan_ext(out, ch);

--- a/md380.c
+++ b/md380.c
@@ -886,6 +886,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:

--- a/rd5r.c
+++ b/rd5r.c
@@ -945,10 +945,8 @@ static void print_chan_base(FILE *out, channel_t *ch, int cnum)
 //
 // Print extended parameters of the channel:
 //      TOT Rekey Delay
-//      RX Ref Frequency
-//      RX Ref Frequency
-//      Lone Worker
 //      VOX
+//      Talkaround
 //
 static void print_chan_ext(FILE *out, channel_t *ch)
 {
@@ -1014,6 +1012,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-4d", ch->contact_name_index);
 
 #ifdef PRINT_RARE_PARAMS
+        fprintf(out, "      ");
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:
@@ -1076,7 +1076,7 @@ static void print_analog_channels(FILE *out, int verbose)
     }
     fprintf(out, "Analog  Name             Receive   Transmit Power Scan TOT RO Admit  Squelch RxTone TxTone Width");
 #ifdef PRINT_RARE_PARAMS
-    fprintf(out, " Dly RxRef TxRef LW VOX TA RxSign TxSign");
+    fprintf(out, " Dly VOX TA RxSign TxSign");
 #endif
     fprintf(out, "\n");
     for (i=0; i<NCHAN; i++) {

--- a/uv380.c
+++ b/uv380.c
@@ -913,7 +913,7 @@ static void print_digital_channels(FILE *out, int verbose)
     }
     fprintf(out, "Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact");
 #ifdef PRINT_EXTENDED_PARAMS
-    fprintf(out, "AS InCall Sq Dly RxRef TxRef LW VOX EmSys Privacy  PN PCC EAA DCC DCDM");
+    fprintf(out, " AS InCall Sq Dly RxRef TxRef LW VOX EmSys Privacy  PN PCC EAA DCC DCDM");
 #endif
     fprintf(out, "\n");
     for (i=0; i<NCHAN; i++) {
@@ -943,6 +943,8 @@ static void print_digital_channels(FILE *out, int verbose)
             fprintf(out, "%-5d", ch->contact_name_index);
 
 #ifdef PRINT_EXTENDED_PARAMS
+        fprintf(out, "     "):
+
         print_chan_ext(out, ch);
 
         // Extended digital parameters of the channel:


### PR DESCRIPTION
Without:
```
Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact Dly VOX TA EmSys Privacy  PN PCC EAA DCC
   19   OK0BRQ-CZ        439.550   -7.6     High  4    -   -  -      1     1    1    1   5   -   -  -     -        -  -   -   -    # National Czech
```

After this patch:
```
Digital Name             Receive   Transmit Power Scan TOT RO Admit  Color Slot RxGL TxContact Dly VOX TA EmSys Privacy  PN PCC EAA DCC
   19   OK0BRQ-CZ        439.550   -7.6     High  4    -   -  -      1     1    1    1         5   -   -  -     -        -  -   -   -    # National Czech
```