### PR TITLE
allow override of cc and cflags/ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-CC		= gcc
+CC		?= gcc
 
 VERSION         = $(shell git describe --tags --abbrev=0)
 GITCOUNT        = $(shell git rev-list HEAD --count)
 UNAME           = $(shell uname)
-CFLAGS		= -g -O -Wall -Werror -DVERSION='"$(VERSION).$(GITCOUNT)"'
-LDFLAGS		= -g
+CFLAGS		?= -g -O -Wall -Werror
+CFLAGS		+= -DVERSION='"$(VERSION).$(GITCOUNT)"'
+LDFLAGS		?= -g
 
 OBJS		= main.o util.o radio.o dfu-libusb.o uv380.o md380.o rd5r.o gd77.o hid.o serial.o d868uv.o
 LIBS            = -lusb-1.0


### PR DESCRIPTION
Most distro build systems expect to be able to override these things.  this should keep your defaults while allowing override.